### PR TITLE
Fix/2843 bg color update infolist

### DIFF
--- a/src/pages/lists/action-list/action-list-local-actions/index.tsx
+++ b/src/pages/lists/action-list/action-list-local-actions/index.tsx
@@ -89,6 +89,13 @@ const useStyles = makeStyles((theme: Theme) => ({
         display: 'block',
         padding: 0,
     },
+    changeBackgroundColor: {
+        [theme.breakpoints.up('md')]: {
+            '&:hover': {
+                backgroundColor: 'transparent',
+            },
+        },
+    },
     deviceEditMobileContainer: {
         display: 'flex',
         flexDirection: 'column',
@@ -413,6 +420,7 @@ export const ActionListLocalActions = (): JSX.Element => {
                                 <InfoListItem
                                     classes={{
                                         listItemText: classes.listItemText,
+                                        root: classes.changeBackgroundColor,
                                     }}
                                     data-testid="infoListItem"
                                     title={'Language'}


### PR DESCRIPTION
<!-- If this pull request fixes an Issue, link it below. If not, you can remove the line below -->
Fixes [342](https://github.com/brightlayer-ui/react-component-library/issues/342) .


<!-- Instruction for PR reviewers, if more complicated than a simple yarn start -->
#### To Test:
- Go to React Design Pattern, "/with-local-actions"
- Hover / Click on the list item for "Language". Observe that nothing happened
- Shrink to mobile. Observe that hover color works correctly
- Shrink back to desktop size
- Observe that there is an unexpected hover color for the "Language"
